### PR TITLE
Настройка json-server

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,18 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  server: {
+    proxy: {
+      "/api/tasks": {
+        target: "http://localhost:3001/tasks",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api\/tasks/, ""),
+      },
+      "/api/users": {
+        target: "http://localhost:3001/users",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api\/users/, ""),
+      },
+    },
+  },
+});


### PR DESCRIPTION
Что выполнено
- Установлен json-server
- Настроено проксирование в vite.config.js
- Запросы на /api/tasks корректно проксируются на http://localhost:3001/tasks
- Запросы на /api/users корректно проксируются на http://localhost:3001/users
